### PR TITLE
feat: Add titles to text notes

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -96,6 +96,27 @@ body {
 }
 
 /* --- Note Specific --- */
+.note-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.note-title {
+    flex: 1;
+    border: none;
+    font-size: 16px;
+    font-weight: 600;
+    padding: 4px;
+    border-radius: 4px;
+    background: transparent;
+}
+.note-title:focus {
+    background: #f1f3f5;
+    outline: none;
+}
+
+
 .note-container {
     background: var(--container-bg);
     border-radius: 8px;
@@ -103,7 +124,7 @@ body {
     padding: 8px;
     border: 1px solid var(--border-color);
     display: flex;
-    align-items: flex-start;
+    flex-direction: column; /* This stacks the items vertically */
 }
 
 .note-textarea {

--- a/src/popup.js
+++ b/src/popup.js
@@ -103,11 +103,21 @@ function renderTextNote(note) {
     const noteDiv = document.createElement('div');
     noteDiv.className = 'note-container';
     noteDiv.innerHTML = `
+        <div class="note-header">
+            <input type="text" class="note-title" data-id="${note.id}" value="${note.title}" placeholder="Note Title">
+            <button class="btn-delete-item" data-id="${note.id}">✕</button>
+        </div>
         <textarea class="note-textarea" data-id="${note.id}" placeholder="Start typing your note...">${note.content}</textarea>
-        <button class="btn-delete-item" data-id="${note.id}">✕</button>
     `;
     contentArea.appendChild(noteDiv);
     
+    // Event listeners
+    const titleInput = noteDiv.querySelector('.note-title');
+    titleInput.addEventListener('input', () => {
+        note.title = titleInput.value;
+        scheduleSave();
+    });
+
     const textarea = noteDiv.querySelector('textarea');
     textarea.addEventListener('input', () => {
         note.content = textarea.value;
@@ -190,7 +200,7 @@ function addContent(type) {
     let newItem;
     
     if (type === 'note') {
-        newItem = { id, type: 'note', content: '' };
+        newItem = { id, type: 'note', title: 'New Note', content: '' };
     } else if (type === 'checklist') {
         newItem = { 
             id, 


### PR DESCRIPTION
This PR adds a title field to text notes, allowing for better organization. It updates the data structure to include a `title` property and modifies the UI to include a title input field above the note's content area. This is a sub-task of Epic 1.