### PR TITLE
feat: Make notes and checklists collapsible

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -95,6 +95,18 @@ body {
     color: var(--muted-color);
 }
 
+/* --- Note & Checklist Shared Styles --- */
+.collapse-icon {
+    padding-right: 8px;
+    cursor: pointer;
+    font-size: 12px;
+    user-select: none; /* Prevents text selection on click */
+}
+
+.note-header, .checklist-header {
+    cursor: pointer;
+}
+
 /* --- Note Specific --- */
 .note-header {
     display: flex;
@@ -116,21 +128,20 @@ body {
     outline: none;
 }
 
-
 .note-container {
     background: var(--container-bg);
     border-radius: 8px;
     margin-bottom: 12px;
-    padding: 8px;
+    padding: 12px;
     border: 1px solid var(--border-color);
     display: flex;
-    flex-direction: column; /* This stacks the items vertically */
+    flex-direction: column;
 }
 
 .note-textarea {
     flex: 1;
     border: none;
-    padding: 8px;
+    padding: 8px 4px;
     font-family: 'Menlo', 'Monaco', monospace;
     font-size: 13px;
     line-height: 1.5;
@@ -138,6 +149,10 @@ body {
     outline: none;
     min-height: 60px;
     background: transparent;
+}
+
+.note-container.collapsed .note-textarea {
+    display: none;
 }
 
 /* --- Checklist Specific --- */
@@ -226,6 +241,12 @@ body {
 }
 .btn-add-checklist-item:hover {
     text-decoration: underline;
+}
+
+.checklist-container.collapsed .checklist-description,
+.checklist-container.collapsed .checklist-items,
+.checklist-container.collapsed .btn-add-checklist-item {
+    display: none;
 }
 
 /* --- Welcome Message --- */

--- a/src/popup.js
+++ b/src/popup.js
@@ -101,9 +101,10 @@ function renderWelcomeMessage() {
 
 function renderTextNote(note) {
     const noteDiv = document.createElement('div');
-    noteDiv.className = 'note-container';
+    noteDiv.className = `note-container ${note.isCollapsed ? 'collapsed' : ''}`;
     noteDiv.innerHTML = `
-        <div class="note-header">
+        <div class="note-header" data-id="${note.id}">
+            <span class="collapse-icon">${note.isCollapsed ? '▶' : '▼'}</span>
             <input type="text" class="note-title" data-id="${note.id}" value="${note.title}" placeholder="Note Title">
             <button class="btn-delete-item" data-id="${note.id}">✕</button>
         </div>
@@ -112,6 +113,16 @@ function renderTextNote(note) {
     contentArea.appendChild(noteDiv);
     
     // Event listeners
+    noteDiv.querySelector('.note-header').addEventListener('click', (e) => {
+        // Prevent toggling when interacting with input or button
+        if (e.target.matches('input') || e.target.matches('button')) {
+            return;
+        }
+        note.isCollapsed = !note.isCollapsed;
+        scheduleSave();
+        render();
+    });
+
     const titleInput = noteDiv.querySelector('.note-title');
     titleInput.addEventListener('input', () => {
         note.title = titleInput.value;
@@ -131,7 +142,7 @@ function renderTextNote(note) {
 
 function renderChecklist(checklist) {
     const checklistDiv = document.createElement('div');
-    checklistDiv.className = 'checklist-container';
+    checklistDiv.className = `checklist-container ${checklist.isCollapsed ? 'collapsed' : ''}`;
     
     const itemsHtml = checklist.items.map(item => `
         <div class="checklist-item ${item.done ? 'done' : ''}">
@@ -142,7 +153,8 @@ function renderChecklist(checklist) {
     `).join('');
     
     checklistDiv.innerHTML = `
-        <div class="checklist-header">
+        <div class="checklist-header" data-id="${checklist.id}">
+            <span class="collapse-icon">${checklist.isCollapsed ? '▶' : '▼'}</span>
             <input type="text" class="checklist-title" data-id="${checklist.id}" value="${checklist.title}" placeholder="Checklist Title">
             <button class="btn-delete-item" data-id="${checklist.id}">✕</button>
         </div>
@@ -154,6 +166,15 @@ function renderChecklist(checklist) {
     contentArea.appendChild(checklistDiv);
 
     // Event listeners
+    checklistDiv.querySelector('.checklist-header').addEventListener('click', (e) => {
+        if (e.target.matches('input') || e.target.matches('button')) {
+            return;
+        }
+        checklist.isCollapsed = !checklist.isCollapsed;
+        scheduleSave();
+        render();
+    });
+
     checklistDiv.querySelector('.checklist-title').addEventListener('input', (e) => {
         checklist.title = e.target.value;
         scheduleSave();
@@ -206,13 +227,14 @@ function addContent(type) {
     let newItem;
     
     if (type === 'note') {
-        newItem = { id, type: 'note', title: 'New Note', content: '' };
+        newItem = { id, type: 'note', title: 'New Note', content: '', isCollapsed: false };
     } else if (type === 'checklist') {
-        newItem = { 
-            id, 
-            type: 'checklist', 
+        newItem = {
+            id,
+            type: 'checklist',
             title: 'My Checklist',
             description: '',
+            isCollapsed: false,
             items: [{ id: `item-${Date.now()}`, text: '', done: false }]
         };
     }


### PR DESCRIPTION
This PR introduces collapsible sections for both notes and checklists to improve UX with many items. Users can click the header to expand or collapse content. The state is saved across sessions. This is a sub-task of Epic 1.